### PR TITLE
Supply values to all occurences of dependency in a rule

### DIFF
--- a/src/norswap/uranium/Rule.java
+++ b/src/norswap/uranium/Rule.java
@@ -127,9 +127,20 @@ public final class Rule
 
     /** Called by the Reactor to supply a dependency value. */
     void supply (Attribute dependency, Object value) {
-        int i = NArrays.indexOf(dependencies, dependency);
-        dependencyValues[i] = value;
-        if (--unsatisfied <= 0) { // could be run multiple times
+        // Supply the value to all dependencies that match the supplied attribute.
+        // Sometimes, multiple equal dependencies can occur (example: left and right types in a
+        // binary expression, where the left and right type decls happen to point to the same class).
+        // In this case, we want to supply the value to all of them.
+        for (int i = 0; i < dependencies.length; ++i){
+            if (Objects.equals(dependencies[i], dependency) && dependencyValues[i] == null) {
+                unsatisfied--;
+
+                // Supply the value
+                dependencyValues[i] = value;
+            }
+        }
+
+        if (unsatisfied <= 0) { // could be run multiple times
             unsatisfied = 0;
             reactor.enqueue(this);
         }


### PR DESCRIPTION
Hello,

I was in the middle of implementing operator overloading in Sigh when I found a bug (or intended feature?) in the attribute supply system.

The problem is that if two dependencies in a rule are equivalent (for example if a `leftDecl` and `rightDecl` in a binary operation are pointing to the same class declaration), the ``Rule.supply`` function will always store the value in the first dependency and leave the others to `null`:

```java
private void binaryExpression(BinaryExpressionNode node) {
    Scope callerScope = scope;

    // Find the types of operands
    R.rule()
        .using(node.left.attr("type"), node.right.attr("type"))
        .by(r -> {
            Type left = r.get(0);
            Type right = r.get(1);

            // Retrieve their declarations
            DeclarationNode leftDecl = left.decl();
            DeclarationNode rightDecl = right.decl();

            // Retrieve their scopes
            R.rule()
                .using(leftDecl.attr("scope"), rightDecl.attr("scope"))
                .by(r2 -> {
                    Scope leftScope = r2.get(0);
                    Scope rightScope = r2.get(1);
                    // ^ if leftDecl and rightDecl are the same (example: both are objects of
                    // the same class), uranium will only fill the first scope because both
                    // attributes would be equal, and rightScope would be null

                    // So, we must add an additional check
                    if (leftDecl.equals(rightDecl)) {
                        rightScope = leftScope;
                    }

                    // Find an operator that matches the types in the scopes
                    findCommutativeFunction(node, node.operator.toString(), leftScope,
                        rightScope, callerScope, inferenceContext, left, right);
                });
        });
}
```

The reason is that the ``Rule.supply`` function uses `indexOf` to find the index of the slot, which always returns the first occurence.

To solve this problem, I modified the function to assign the value to all matching attributes.

Have a good day,

Martin Danhier